### PR TITLE
If folderStatus() failed, don't execute setError.

### DIFF
--- a/src/async/imap/MCIMAPFolderInfoOperation.cpp
+++ b/src/async/imap/MCIMAPFolderInfoOperation.cpp
@@ -62,12 +62,11 @@ void IMAPFolderInfoOperation::main()
     mInfo->setAllowsNewPermanentFlags(session()->session()->allowsNewPermanentFlags());
 
     if(mIncludeUnSeen){
-        IMAPFolderStatus *status = session()->session()->folderStatus(folder(), &error);
-        if (error != ErrorNone) {
-            setError(error);
-            return;
+        ErrorCode statusError = ErrorNone;
+        IMAPFolderStatus *status = session()->session()->folderStatus(folder(), &statusError);
+        if (statusError == ErrorNone) {
+            mInfo->setUnSeenMessageCount(status->unseenCount());
         }
-        mInfo->setUnSeenMessageCount(status->unseenCount());
     }
     
     setError(error);

--- a/src/async/imap/MCIMAPFolderInfoOperation.cpp
+++ b/src/async/imap/MCIMAPFolderInfoOperation.cpp
@@ -66,6 +66,8 @@ void IMAPFolderInfoOperation::main()
         IMAPFolderStatus *status = session()->session()->folderStatus(folder(), &statusError);
         if (statusError == ErrorNone) {
             mInfo->setUnSeenMessageCount(status->unseenCount());
+        } else {
+            mInfo->setUnSeenMessageCount(-1);
         }
     }
     


### PR DESCRIPTION
If folderStatus() failed, don't execute setError.