### PR TITLE
Try "list" command if "xlist" command failed in IMAPSession::fetchAllFolders

### DIFF
--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -1614,6 +1614,10 @@ Array * /* IMAPFolder */ IMAPSession::fetchAllFolders(ErrorCode * pError)
     
     if (mXListEnabled) {
         r = mailimap_xlist(mImap, MCUTF8(prefix), "*", &imap_folders);
+        if (r == MAILIMAP_ERROR_PARSE) {
+            clearStreamBufferOfLastCommand();
+            r = mailimap_list(mImap, MCUTF8(prefix), "*", &imap_folders);
+        }
     }
     else {
         r = mailimap_list(mImap, MCUTF8(prefix), "*", &imap_folders);


### PR DESCRIPTION
Try "list" command if "xlist" command failed in IMAPSession::fetchAllFolders