### PR TITLE
ECANDR-7149: [Thread] Thread title has more space after replying one by one.

### DIFF
--- a/src/core/basetypes/MCString.cpp
+++ b/src/core/basetypes/MCString.cpp
@@ -361,7 +361,8 @@ static char * etpan_make_quoted_printable(const char * display_charset,
             }
             
             if (* end != '\0') {
-                mmap_string_append_c(mmapstr, ' ');
+                // modified by Edison. (Jira: ECANDR-7149)
+                // mmap_string_append_c(mmapstr, ' ');
                 mmap_string_append_len(mmapstr, end, cur - end);
             }
         }


### PR DESCRIPTION
ECANDR-7149: [Thread] Thread title has more space after replying one by one.
Don't add a space between a quoted word and a unquoted word.