### PR TITLE
Set error code of login to ErrorGmailTooManySimultaneousConnections if server response contains "too many concurrent connections"

### DIFF
--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -977,6 +977,9 @@ void IMAPSession::login(ErrorCode * pError)
         else if (mIsGmail && response->locationOfStringCaseInsensitive(MCSTR("Application-specific password required")) != -1) {
             * pError = ErrorGmailApplicationSpecificPasswordRequired;
         }
+        else if (response->locationOfStringCaseInsensitive(MCSTR("too many concurrent connections")) != -1) {
+            * pError = ErrorGmailTooManySimultaneousConnections;
+        }
         else if (response->locationOfStringCaseInsensitive(MCSTR("http://me.com/move")) != -1) {
             * pError = ErrorMobileMeMoved;
         }


### PR DESCRIPTION
JIRA:
https://yipitdata5.atlassian.net/browse/DC-3419
[Feedback] keep getting an error banner that says "cannot authenticate with moxie@metrocast.net"