### PR TITLE
When fetching only uids, if a parsing error occurs, discarded the incomplete result.

### DIFF
--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -2773,7 +2773,9 @@ IMAPSyncResult * IMAPSession::fetchMessages(String * folder, IMAPMessagesRequest
 //        return NULL;
 //    }
     else if (hasError(r)) {
-        if ((r == MAILIMAP_ERROR_PARSE || r == MAILIMAP_ERROR_FETCH || r == MAILIMAP_ERROR_UID_FETCH) && messages->count() > 0) {
+        bool fetchOnlyUid = (requestKind == IMAPMessagesRequestKindUid ||
+                             requestKind == (IMAPMessagesRequestKindUid | IMAPMessagesRequestKindGmailMessageID));
+        if ((r == MAILIMAP_ERROR_PARSE || r == MAILIMAP_ERROR_FETCH || r == MAILIMAP_ERROR_UID_FETCH) && messages->count() > 0 && !fetchOnlyUid) {
             // For AT&T account, the response is NO, but the body struct is returned.
             // No need to release the fetch_result. No need to do the MboxMailWorkaround.
             MCLog("fetch list with error return code.");


### PR DESCRIPTION
When fetching only uids, if a parsing error occurs, discarded the incomplete result.