### PR TITLE
EC-12005: [Account] Always loading when refresh in my outlook account

### DIFF
--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -2773,6 +2773,9 @@ IMAPSyncResult * IMAPSession::fetchMessages(String * folder, IMAPMessagesRequest
 //        return NULL;
 //    }
     else if (hasError(r)) {
+        if (r == MAILIMAP_ERROR_PARSE) {
+            clearStreamBufferOfLastCommand();
+        }
         bool fetchOnlyUid = (requestKind == IMAPMessagesRequestKindUid ||
                              requestKind == (IMAPMessagesRequestKindUid | IMAPMessagesRequestKindGmailMessageID));
         if ((r == MAILIMAP_ERROR_PARSE || r == MAILIMAP_ERROR_FETCH || r == MAILIMAP_ERROR_UID_FETCH) && messages->count() > 0 && !fetchOnlyUid) {


### PR DESCRIPTION
If parsing messages fails, clear the stream buffer.

Jira:
https://yipitdata5.atlassian.net/browse/EC-12005