### PR TITLE
DC-4375: The subject is displayed messily.

### DIFF
--- a/src/core/imap/MCIMAPSession.cpp
+++ b/src/core/imap/MCIMAPSession.cpp
@@ -2455,11 +2455,11 @@ static void msg_att_handler(struct mailimap_msg_att * msg_att, void * context)
                         msg->setPartData(Data::dataWithBytes(bytes, (unsigned int) length));
                         hasBody = true;
                     } else {
-                        String * charset = discoverCharset((AbstractPart*)msg->mainPart());
+                        // String * charset = discoverCharset((AbstractPart*)msg->mainPart());
                         // used utf-7 to decode string which has '+' will generate unrecognizable characters
-                        if (charset != NULL && charset->caseInsensitiveCompare(MCSTR("utf-7")) != 0) {
-                            msg->header()->setDefaultCharset(charset);
-                        }
+                        // if (charset != NULL && charset->caseInsensitiveCompare(MCSTR("utf-7")) != 0) {
+                        //     msg->header()->setDefaultCharset(charset);
+                        // }
                         msg->header()->importHeadersData(Data::dataWithBytes(bytes, (unsigned int) length));
                         hasHeader = true;
                     }


### PR DESCRIPTION
Jira:
https://yipitdata5.atlassian.net/issues/DC-4375

Zendesk: 
https://edisonmail.zendesk.com/agent/tickets/419260

Do not use the first part's charset as the default charset for the message header.